### PR TITLE
Feature newui pithos auth and settings

### DIFF
--- a/snf-django-lib/snf_django/lib/api/proxy/utils.py
+++ b/snf-django-lib/snf_django/lib/api/proxy/utils.py
@@ -28,13 +28,20 @@ except ImportError:
         return header_name.lower() in _hop_headers
 
 
+# Headers which don't get prefixed with HTTP_ but should get forwarded
+ALLOWED_PLAIN_HTTP_HEADERS = ['CONTENT_TYPE']
+
 def fix_header(k, v):
     prefix = 'HTTP_'
     if k.startswith(prefix):
         k = k[len(prefix):].title().replace('_', '-')
+
+    if k in ALLOWED_PLAIN_HTTP_HEADERS:
+        k = k.title().replace('_', '-')
+
     return k, v
 
 
 def forward_header(k):
-    return k.upper() not in ['HOST', 'CONTENT_LENGTH', 'CONTENT_TYPE'] and \
+    return k.upper() not in ['HOST', 'CONTENT_LENGTH'] and \
         not is_hop_by_hop(k) and not '.' in k

--- a/snf-ui-app/synnefo_ui/ui/templates/ui/index.html
+++ b/snf-ui-app/synnefo_ui/ui/templates/ui/index.html
@@ -17,7 +17,7 @@
   <body>
     
     <script>
-      window.SETTINGS = {{ app_settings|safe }}
+      window.SETTINGS = {{ app_settings|safe }};
     </script>
     <script src="{{ MEDIA_URL }}ui/assets/vendor.js"></script>
     <script src="{{ MEDIA_URL }}ui/assets/ui-web.js"></script>

--- a/snf-ui-app/synnefo_ui/ui/views.py
+++ b/snf-ui-app/synnefo_ui/ui/views.py
@@ -29,6 +29,7 @@ from astakosclient import AstakosClient, parse_endpoints
 
 # TODO: ui should include its own proxy paths
 from pithos.api.settings import ASTAKOS_AUTH_PROXY_PATH
+from pithos.api.settings import ASTAKOS_ACCOUNT_PROXY_PATH
 
 def home(request):
 
@@ -41,7 +42,10 @@ def home(request):
     app_settings = {
         'branding': get_branding_dict(),
         'token': token,
-        'auth_url': '/' + ASTAKOS_AUTH_PROXY_PATH
+        'auth_url': '/' + ASTAKOS_AUTH_PROXY_PATH,
+        'proxy': {
+            'astakosAccount': '/' + ASTAKOS_ACCOUNT_PROXY_PATH
+        }
     }
 
     context = {

--- a/snf-ui-app/ui-web/app/initializers/settings.js
+++ b/snf-ui-app/ui-web/app/initializers/settings.js
@@ -1,17 +1,50 @@
 import Ember from "ember";
+import Settings from "../snf/settings";
 
-var settings = Ember.Object.extend(SETTINGS);
+var settings = Settings.create(SETTINGS);
 
-export var initialize = function(container, app) {
-  app.register('settings:main', settings, {singleton:true});
+var registerAndAdvance = function(settings, container, app, err) {
+  app.register('settings:main', settings, {singleton:true, instantiate: false});
   app.inject('controller', 'settings', 'settings:main');
   app.inject('adapter', 'settings', 'settings:main');
   app.inject('model', 'settings', 'settings:main');
   app.inject('route', 'settings', 'settings:main');
+  app.advanceReadiness();
+}
+
+var resolveAuth = function(settings, container, app) {
+  var token = settings.get('token'), loginUrl = settings.get('loginUrl');
+  if (!token) {
+    if (settings.localToken) {
+      token = window.prompt("Gimme your token");
+      settings.set('token', token);
+    } else {
+      if (!loginUrl) { throw "Invalid login url"; }
+      window.location = loginUrl;
+    }
+  }
+  return settings.resolveUser();
+}
+
+
+export var initialize = function(container, app) {
+  app.deferReadiness();
+  
+  var authUrl = settings.get("authUrl");
+  if (authUrl) {
+
+    var _bind = function(fn) {return fn.bind(this, settings, container, app);}
+
+    settings.extendFromUrl(authUrl, {method: 'post'})
+      .then(_bind(resolveAuth), _bind(resolveAuth))
+      .then(_bind(registerAndAdvance)).catch(function(err) {
+        console.error(err);
+        app.advanceReadiness();
+      });; 
+  }
 };
 
 export default {
   name: 'settings',
-
   initialize: initialize
 };

--- a/snf-ui-app/ui-web/app/snf/adapters/base.js
+++ b/snf-ui-app/ui-web/app/snf/adapters/base.js
@@ -64,7 +64,7 @@ export default DS.RESTAdapter.extend({
     var hosts = this.get('settings');
     var key = this.get('apiKey') + '_url';
     if (hosts) { 
-      return hosts[key];
+      return hosts.get(key);
     }
     throw Error("No key '%@' found in '%@'".fmt(key, hosts));
   }.property('settings'),

--- a/snf-ui-app/ui-web/app/snf/settings.js
+++ b/snf-ui-app/ui-web/app/snf/settings.js
@@ -1,0 +1,65 @@
+import Ember from 'ember';
+import {raw as ajax} from 'ic-ajax';
+
+
+export default Ember.Object.extend({
+  serviceCatalog: [],
+  services: function() {
+    var catalog = this.get('serviceCatalog');
+    var map = {};
+    
+    catalog.forEach(function(service) {
+      var name = Ember.String.camelize(service.name);
+      map[name] = Ember.Object.create(service);
+      var endpoints = {};
+      service.endpoints.forEach(function(points) {
+        var stripped;
+        for (var p in points) {
+          stripped = p;
+          if (p.split(":").length > 1) {
+            stripped = p.split(":")[1];
+          }
+          endpoints[stripped] = points[p];
+        }
+      });
+      map[name].set('endpoints', Ember.Object.create(endpoints));
+    });
+    return map;
+  }.property('serviceCatalog'),
+
+  loginUrl: function() {
+    var ui, loc, login;
+    ui = this.get('services.astakosAccount.endpoints.uiURL');
+    loc = window.location.toString();
+    login = ui.replace(/\/$/, '') + '/login/?next=' + loc;
+    return login;
+  }.property('services.astakosAccount.endpoints.uiURL'),
+
+  authUrl: function() {
+    var auth = this.get('auth_url');
+    return auth.replace(/\/$/g, '') + '/' + 'tokens/'
+  }.property('auth_url'),
+
+  extendFromUrl: function(url, opts) {
+   return ajax(url, opts).then(function(data) {
+     this.set('serviceCatalog', data.response.access.serviceCatalog);
+     return this;
+   }.bind(this));
+  },
+
+  resolveUser: function() {
+    return ajax({
+      url: this.get('authUrl'),
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      type: 'json',
+      // TODO: also permit login using username/password
+      data: JSON.stringify({auth:{token:{id: this.get('token')}}})
+    }).then(function(data) {
+      this.set('tokenInfo', data.response.token);
+    }.bind(this));
+  }
+
+});


### PR DESCRIPTION
- Simplify server side settings dependencies. UI is now able to resolve api endpoints and user info 
  via astakos account api.
- Handle unauthenticated users by redirecting them to astakos login url.

*notice: The last commit includes a modification in snf-django-lib which is required in order for astakos authenticate requests to work. In development environments you should update the django-lib package.

``` bash
$ cd snf-django-lib; 
$ python setup.py develop -N; 
$ /etc/init.d/gunicorn restart;
```
