### PR TITLE
ui: Permit override of default settings from url fragment

### DIFF
--- a/snf-ui-app/ui-web/app/initializers/settings.js
+++ b/snf-ui-app/ui-web/app/initializers/settings.js
@@ -10,6 +10,9 @@ var registerAndAdvance = function(settings, container, app, err) {
   app.inject('model', 'settings', 'settings:main');
   app.inject('route', 'settings', 'settings:main');
   app.advanceReadiness();
+  
+  // cache settings to cookie
+  settings.persist('ui_settings');
 }
 
 var resolveAuth = function(settings, container, app) {
@@ -29,7 +32,10 @@ var resolveAuth = function(settings, container, app) {
 
 export var initialize = function(container, app) {
   app.deferReadiness();
-  
+ 
+  settings.loadFromCookie("ui_settings");
+  settings.loadFromQS(window.location.hash.replace(/^#/, '') || '');
+
   var authUrl = settings.get("authUrl");
   if (authUrl) {
 

--- a/snf-ui-app/ui-web/app/snf/settings.js
+++ b/snf-ui-app/ui-web/app/snf/settings.js
@@ -2,6 +2,9 @@ import Ember from 'ember';
 import {raw as ajax} from 'ic-ajax';
 
 var alias = Ember.computed.alias;
+var qsToObject = function(qs) {
+  return JSON.parse('{"' + decodeURI(qs).replace(/"/g, '\\"').replace(/&/g, '","').replace(/=/g,'":"') + '"}');
+}
 
 var serviceUrl = function(service, url) {
   var depKey;
@@ -75,6 +78,34 @@ export default Ember.Object.extend({
       this.set('tokenInfo', data.response.access.token);
       this.set('user', data.response.access.user);
     }.bind(this));
+  },
+
+  loadFromQS: function(qs) {
+    try {
+      var obj = qsToObject(qs);
+    } catch (err) {};
+    this.setProperties(obj);
+  },
+  
+  loadFromCookie: function(name) {
+    var reg, value, matched;
+    reg = new RegExp(name+'=(.*?);');
+    matched = document.cookie.toString().match(reg);
+    if (matched && matched[1]) {
+      value = decodeURIComponent(matched[1]);
+      value = JSON.parse(value);
+      this.setProperties(value);
+    }
+  },
+
+  persist: function(name, data, props) {
+    var expires, value;
+    props = props || ['auth_url', 'token'];
+    expires = (new Date())
+    expires.setDate(expires.getDate() + 1);
+    value = JSON.stringify(this.getProperties.apply(this, props));
+    value = encodeURIComponent(value);
+    document.cookie = name + "=" + value + ";" + expires.toUTCString();
   },
 
   // aliases


### PR DESCRIPTION
a tiny hack to easily test app with external deployments.

e.g.
google-chrome --disable-web-security https://pithos.synnefo.live/ui/#auth_url=https://accounts.okeanos.grnet.gr/identity/v2.0&localToken=1&proxy=&token=
